### PR TITLE
Fix: vmm_map_memory & syscall_nanosleep

### DIFF
--- a/kernel/sharedmemory.c
+++ b/kernel/sharedmemory.c
@@ -204,7 +204,7 @@ static void* sharedmemory_mmap(File* file, uint32_t size, uint32_t offset, uint3
         MapInfo* info = (MapInfo*)kmalloc(sizeof(MapInfo));
         memset((uint8_t*)info, 0, sizeof(MapInfo));
         info->process = g_current_thread->owner;
-        info->v_address = result;
+        info->v_address = result == 0 ? 0 : (uint32_t)result;
         info->page_count = count;
 
         list_append(shared_mem->mmapped_list, info);

--- a/kernel/syscalls.c
+++ b/kernel/syscalls.c
@@ -131,7 +131,7 @@ int syscall_shmget(int32_t key, size_t size, int flag);
 void * syscall_shmat(int shmid, const void *shmaddr, int shmflg);
 int syscall_shmdt(const void *shmaddr);
 int syscall_shmctl(int shmid, int cmd, struct shmid_ds *buf);
-int syscall_nanosleep(const struct timespec *req, struct timespec *rem);
+int syscall_nanosleep(struct timespec *req, struct timespec *rem);
 
 void syscalls_initialize()
 {
@@ -1877,7 +1877,7 @@ int syscall_ptsname_r(int fd, char *buf, int buflen)
     return -1;//on error
 }
 
-int syscall_nanosleep(const struct timespec *req, struct timespec *rem)
+int syscall_nanosleep(struct timespec *req, struct timespec *rem)
 {
     if (!check_user_access(req))
     {


### PR DESCRIPTION
`vmm_map_memory` can also return `NULL`, as a result, `v_address` will be pointed as `NULL`. For a workaround, handling it with 0 should fix this state.
In `syscall_nanosleep`, the `req` param was passed as a constant, and Clang seems to return a warning when compiling. It might not be necessary but I removed `req` from the const position.

Note: This might require some review since I haven't thoroughly tested the changes yet.